### PR TITLE
Add PHPDoc to Challenges Relationship

### DIFF
--- a/app/ChallengeCategory.php
+++ b/app/ChallengeCategory.php
@@ -13,6 +13,9 @@ class ChallengeCategory extends Model
         'challenge_id'
     ];
 
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
     public function challenges()
     {
         return $this->belongsTo('App\Challenge', 'challenge_id', 'id');


### PR DESCRIPTION
As a test for APIDoc: add PHPDoc to `challenges` relationship with valid return class.

This should be valid enough for static documentation generation. 